### PR TITLE
Fix color conversion edge case

### DIFF
--- a/lib/src/quantize_null_safe.dart
+++ b/lib/src/quantize_null_safe.dart
@@ -268,7 +268,8 @@ class CMap {
 
   nearest(color) {
     var vboxes = this.vboxes;
-    double? d1, d2, pColor;
+    double? d1, d2;
+    List<int>? pColor;
 
     for (var i = 0; i < vboxes.size(); i++) {
       d2 = math.sqrt(math.pow(color[0] - vboxes.peek(i).color[0], 2) +

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -59,11 +59,12 @@ List<int> fromRGBtoHSV(List<int> list) {
 List<int> fromHSVtoRGB(List<int> list) {
   assert(list.length == 3);
 
-  var h = list[0];
+  var h = list[0] % 360;
   var s = list[1] / 100;
   var v = list[2] / 100;
-  var h1 = (h ~/ 60) % 6;
-  var f = h / 60 - h1;
+  var hSection = h / 60;
+  var h1 = hSection.floor() % 6;
+  var f = hSection - h1;
   var p = v * (1 - s);
   var q = v * (1 - f *s );
   var t = v * (1 - (1 - f) * s);

--- a/test/color_thief_dart_test.dart
+++ b/test/color_thief_dart_test.dart
@@ -11,4 +11,9 @@ void main() {
   test('utils.fromHSVtoRGB', () {
     expect(fromHSVtoRGB([90, 90, 90]).toString(), [126, 230, 23].toString());
   });
+
+  test('utils.fromHSVtoRGB h 360 should equal h 0', () {
+    expect(fromHSVtoRGB([360, 100, 100]).toString(),
+        fromHSVtoRGB([0, 100, 100]).toString());
+  });
 }


### PR DESCRIPTION
## Summary
- fix nearest color return type in quantize
- handle h=360 in HSV->RGB conversion
- test HSV edge case

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d47ebb2c8320bb06a4239e364638